### PR TITLE
fix .npmignore didn't match Tests.meta file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,1 @@
-Tests
+/Tests*

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
-/Tests*
+Tests
+Tests.meta


### PR DESCRIPTION
Hey, thank you for a great tool for the Asset Store publishers!

I've started tackling with it and noticed it produces these warnings in Unity 2019.4 and 2020.1 after adding a package to the Unity project:

```
A meta data file (.meta) exists but its asset 'Packages/com.needle.upm-in-unitypackage/Tests' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.

Couldn't delete Packages/com.needle.upm-in-unitypackage/Tests.meta because it's in an immutable folder.
```

At the Unity 2020.3 and newer, a new empty Hybrid Packages/Test folder is created with this warning:

`A meta data file (.meta) exists but its folder 'Packages/com.needle.upm-in-unitypackage/Tests' can't be found, and has been created. Empty directories cannot be stored in version control, so it's assumed that the meta data file is for an empty directory in version control. When moving or deleting folders outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.`

After looking into the repo, it seems `.npmignore` had a pattern to ignore `Tests` folder, but it didn't include corresponding `.meta` file which lead to those warnings since .meta file gets into the package without corresponding folder.

I've checked [.npmignore syntax](https://docs.npmjs.com/cli/v7/using-npm/developers#keeping-files-out-of-your-package), and it has the same pattern rules as `.gitignore` file. So here I am, swapped `Tests` with `/Tests*` to ignore both `Tests` folder and `Tests.meta` file at the repo root to avoid loose .meta file slipping into the package.
