### PR TITLE
Show output folder for exported files

### DIFF
--- a/Editor/AssetStoreToolsExtension.cs
+++ b/Editor/AssetStoreToolsExtension.cs
@@ -75,6 +75,7 @@ namespace Needle.PackageTools
 
     public class AssetStoreToolsPatchProvider
     {
+        internal const string outputSubFolder = "Temp"; // NB: this is Unity's "project's Temp folder" so you shouldn't change it
         private static AssetStoreUploadConfig currentUploadConfig;
         
         [InitializeOnLoadMethod]
@@ -102,7 +103,7 @@ namespace Needle.PackageTools
             foreach (var path in uploadConfig.GetExportPaths())
                 GetGUIDsPatch.AddChildrenToResults(results, path);
 
-            var exportFilename = "Temp/HybridPackage_" + Path.GetDirectoryName(AssetDatabase.GetAssetPath(uploadConfig))
+            var exportFilename = outputSubFolder+"/HybridPackage_" + Path.GetDirectoryName(AssetDatabase.GetAssetPath(uploadConfig))
                 .Replace("\\", "/")
                 .Replace("Assets/", "")
                 .Replace("Packages/", "")
@@ -579,7 +580,11 @@ namespace Needle.PackageTools
                     EditorUtility.DisplayProgressBar("Creating .unitypackage", "Done", 1f);
                     EditorUtility.ClearProgressBar();
 
-                    Debug.Log("Created .unitypackage at " + fileName + " in " + (sw.ElapsedMilliseconds / 1000f).ToString("F2") + "s");
+                    /**
+                     * Note: "filename" is actually "relative-folder + filename" (it's wrongly named), so we introduce "outputPreDir" as the (folder containing the folder with the file)
+                     */
+                    var outputPreDir = Path.GetDirectoryName( Application.dataPath );
+                    Debug.Log("Created .unitypackage in " + (sw.ElapsedMilliseconds / 1000f).ToString("F2") + "s at: \""+outputPreDir+"/"+ fileName+"\"" );
                     return false;
                 }
                 

--- a/Editor/AssetStoreUploadConfig.cs
+++ b/Editor/AssetStoreUploadConfig.cs
@@ -121,7 +121,40 @@ namespace Needle.PackageTools
             }
             
             EditorGUILayout.Space();
-            
+            EditorGUILayout.LabelField(new GUIContent("Export to folder:"), EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
+            /** Note: re-using the existing messy code for finding a AssetStoreUploadConfig instance - just need one here */
+            foreach( var o in targets )
+            {
+                if( o is AssetStoreUploadConfig anyConfig )
+                {
+                    var temporaryZipFolder = Environment.GetFolderPath( Environment.SpecialFolder.ApplicationData ) + "/Unity/AssetStoreTools/Export";
+
+                    var exportFolder = "Temp";
+                    var exportFilename = exportFolder+"/HybridPackage_" + Path.GetDirectoryName( AssetDatabase.GetAssetPath( anyConfig ) )
+                                             .Replace( "\\", "/" )
+                                             .Replace( "Assets/", "" )
+                                             .Replace( "Packages/", "" )
+                                             .Replace( "/", "_" )
+                                             .Trim( '_' )
+                                         + ".unitypackage";
+
+
+                    
+                    var outputLocation = Path.GetDirectoryName( Application.dataPath ) + "/"+exportFolder;
+                    GUIStyle myCustomStyle = new GUIStyle( GUI.skin.GetStyle( "label" ) )
+                    {
+                        wordWrap = true
+                    };
+                    EditorGUILayout.LabelField( new GUIContent( outputLocation ), myCustomStyle );
+                    if( GUILayout.Button( "Open export folder" ) )
+                    {
+                        Application.OpenURL( outputLocation );
+                    }
+                    
+                    break;
+                }
+            }
             if(GUILayout.Button("Export for Local Testing" + (targets.Length > 1 ? " [" + targets.Length + "]" : "")))
             {
                 foreach (var o in targets)
@@ -131,7 +164,9 @@ namespace Needle.PackageTools
                     AssetStoreToolsPatchProvider.ExportPackageForConfig(config);
                 }
             }
+            EditorGUI.indentLevel--;
             
+
             EditorGUILayout.Space();
             EditorGUI.BeginDisabled(true);
             EditorGUILayout.Space();

--- a/Readme.md
+++ b/Readme.md
@@ -56,9 +56,12 @@ The resulting .unitypackage files _do not require any additional setup for users
 
 ### Upload Packages to Asset Store
 
+1. Export your Unitypackage (using the instructions above) - the other ways no longer work (Unity changed the assetstore tools)
 1. Install the Asset Store Tools as usual: https://assetstore.unity.com/packages/tools/utilities/asset-store-tools-115
-1. Open <kbd>Asset Store Tools/Package Upload</kbd>
-1. Press <kbd>Select</kbd> and select a local or embedded package
+1. Open <kbd>Asset Store Tools/Upload</kbd>
+1. Find your draft package in the list (must have already created on Unity Publisher Portal)
+1. Choose the "Pre-exported unitypackage" option
+1. Select the .unitypackage you already exported/created 
 2. Make sure "include dependencies" is off - you can now specify them through your package.json!
 3. Press <kbd>Upload</kbd>
 
@@ -78,6 +81,7 @@ The basic flow is:
    This can be a single file, a folder, one or multiple packages, or a combination of these.  
 2. To test your Hybrid Package locally, select your config, and click <kbd>Export for Local Testing</kbd>.  
    This produces exactly the same .unitypackage as on Store upload, so you can test this one by importing it into a different/empty project.  
+1. NB: the above is now a REQUIRED step, it's the only way you can upload
 4. Open <kbd>Asset Store Tools/Package Upload</kbd>
 1. Press <kbd>Select</kbd> and select the directory that contains your upload config, e.g. "My Package Collection"
 3. Press <kbd>Upload</kbd>


### PR DESCRIPTION
Added display of the output folder (because it's not at all obvious where it's going to end up, and if you close the window that auto-opens at end of process - it's gone! Also: Windows10 has a habit of not-repopening Explorer windows that were already open, making it hard to find the file with current design).

Also changes the success message to give the actual filename/location (previous version only gives a relative filepath, which can't be copy/pasted, can't be opened directly, etc)